### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,10 @@ print("Time submitted!")
 ### Get scores
 
 ```gdscript
+var limit = 10;
 var scores = await NG.scoreboard_get_scores(scoreboard_id, limit)
 for score in scores:
-	print("user %s has the score %s" % [score.name, score.formatted_value])
+	print("user %s has the score %s" % [score.user.name, score.formatted_value])
 ```
 
 ## Cloud save & load


### PR DESCRIPTION
Hello!

Recently I was adding a leaderboard for my game, and I found that the examples provided to retreive the player's name (both here and [on the wiki](https://github.com/jefvel/newgrounds-godot-4/wiki/Scoreboards)) did not work, with the error message `Invalid access to property or key 'name' on a base object of type 'RefCounted (NewgroundsScoreboardItem)'`.

After some experimentation, I discovered that the way to retreive an username from the leaderboards is not `score.name` but `score.user.name`. This pull request fixes the example in README.md, but the wiki should probably be updated too.

Thanks for the fantastic plugin! Besides this minor hiccup, it really is extremely easy to implement.