### PR TITLE
Fix broken medal URL

### DIFF
--- a/addons/newgrounds/plugin.gd
+++ b/addons/newgrounds/plugin.gd
@@ -134,7 +134,7 @@ func medals_get(res: NewgroundsResponse):
 		var imgReq = NewgroundsImage.new()
 		imgReq.visible = false;
 		add_child(imgReq)
-		imgReq.url = 'https:' + medal.icon_url;
+		imgReq.url = medal.icon_url;
 		imgReq.on_image_loaded.connect(_set_medal_icon.bind(medal, resource_name, imgReq))
 		
 	loadedMedals = true


### PR DESCRIPTION
Previously got this error while trying to fetch medals/scoreboards:
```
ERROR: Error parsing URL: 'https:https://apifiles.ngfiles.com/icons/medal_secret.png'.
ERROR: core/variant/variant_utility.cpp:1024 - An error occurred in the HTTP request.
```

Newgrounds now returns the full URL, if it didn't previously.
Ex: `https://apifiles.ngfiles.com/icons/medal_secret.png`